### PR TITLE
Update BMXSQL6.m

### DIFF
--- a/Packages/M Transfer/Routines/BMXSQL6.m
+++ b/Packages/M Transfer/Routines/BMXSQL6.m
@@ -343,4 +343,3 @@ LAST(VAR) ; Get last entry in an array //SMH new code
   N SUB3 S SUB3=$O(@VAR@(SUB1,SUB2,""),-1)
   I SUB3="" Q $NA(@VAR@(SUB1,SUB2))
   E  Q $NA(@VAR@(SUB1,SUB2,SUB3))
-


### PR DESCRIPTION
Extra lines at the end throw off the .RO used in import of the routines (and all routines following it)